### PR TITLE
Close notch when dragging file away

### DIFF
--- a/NotchDrop/NotchView.swift
+++ b/NotchDrop/NotchView.swift
@@ -66,7 +66,7 @@ struct NotchView: View {
                 ).animation(vm.animation)
             )
         }
-        .background(dragDetecter)
+        .background(dragDetector)
         .animation(vm.animation, value: vm.status)
         .preferredColorScheme(.dark)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
@@ -136,7 +136,7 @@ struct NotchView: View {
     }
 
     @ViewBuilder
-    var dragDetecter: some View {
+    var dragDetector: some View {
         RoundedRectangle(cornerRadius: notchCornerRadius)
             .foregroundStyle(Color.black.opacity(0.001))  // fuck you apple and 0.001 is the smallest we can have
             .contentShape(Rectangle())

--- a/NotchDrop/NotchView.swift
+++ b/NotchDrop/NotchView.swift
@@ -137,17 +137,24 @@ struct NotchView: View {
 
     @ViewBuilder
     var dragDetecter: some View {
-        if vm.status == .closed {
-            RoundedRectangle(cornerRadius: notchCornerRadius)
-                .foregroundStyle(Color.black.opacity(0.001)) // fuck you apple and 0.001 is the smallest we can have
-                .contentShape(Rectangle())
-                .frame(width: vm.deviceNotchRect.width + vm.dropDetectorRange, height: vm.deviceNotchRect.height + vm.dropDetectorRange)
-                .onDrop(of: [.data], isTargeted: $dropTargeting) { _ in true }
-                .onChange(of: dropTargeting) { newValue in if newValue {
+        RoundedRectangle(cornerRadius: notchCornerRadius)
+            .foregroundStyle(Color.black.opacity(0.001))  // fuck you apple and 0.001 is the smallest we can have
+            .contentShape(Rectangle())
+            .frame(width: notchSize.width + vm.dropDetectorRange, height: notchSize.height + vm.dropDetectorRange)
+            .onDrop(of: [.data], isTargeted: $dropTargeting) { _ in true }
+            .onChange(of: dropTargeting) { isTargeted in
+                if isTargeted && vm.status == .closed{
+                    // Open the notch when a file is dragged over it
                     vm.notchOpen(.drag)
-                    vm.hapticSender.send()
-                } }
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-        }
+                    vm.hapticSender.send()  // Optionally send haptic feedback
+                } else if !isTargeted{
+                    // Close the notch when the dragged item leaves the area
+                    let mouseLocation: NSPoint = NSEvent.mouseLocation
+                    if  !vm.notchOpenedRect.insetBy(dx: vm.inset, dy: vm.inset).contains(mouseLocation){
+                        vm.notchClose()
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     }
 }

--- a/NotchDrop/NotchView.swift
+++ b/NotchDrop/NotchView.swift
@@ -146,7 +146,7 @@ struct NotchView: View {
                 if isTargeted && vm.status == .closed{
                     // Open the notch when a file is dragged over it
                     vm.notchOpen(.drag)
-                    vm.hapticSender.send()  // Optionally send haptic feedback
+                    vm.hapticSender.send()
                 } else if !isTargeted{
                     // Close the notch when the dragged item leaves the area
                     let mouseLocation: NSPoint = NSEvent.mouseLocation


### PR DESCRIPTION
Adjusts the NotchView's DragDetector to close the Notch when a file is dragged away. 

* When you drag a file to the notch, then change your mind and drag it away, you won't have any subsequent need for the notch to stay open
* When you've just taken a file from the notch, I think it's more likely that you'll be finished interacting with it, than that you'll want to grab more files.

This could be togglable option, but in my experience, I've strongly preferred it to auto-close. 

Implementation note: because hovering the AirDrop and TrayDrop take focus from the NotchView, an extra check is required when de-targeting the NotchView to make sure the mouse has actually left the box; ergo the ` if  !vm.notchOpenedRect.insetBy(dx: vm.inset, dy: vm.inset).contains(mouseLocation){` line

P.S., Love this project!

Prior behavior: 

https://github.com/user-attachments/assets/e66ca40e-d120-4c61-a492-d8a57e555b9f

New Behavior:

https://github.com/user-attachments/assets/b9d06549-b1cb-4d8d-a75d-4b9ee4e0c3de

