### PR TITLE
Haptic feedback setting

### DIFF
--- a/NotchDrop/Localizable.xcstrings
+++ b/NotchDrop/Localizable.xcstrings
@@ -540,6 +540,28 @@
         }
       }
     },
+    "Haptic Feedback" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Haptic Feedback"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "触觉反馈"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "觸覺回饋"
+          }
+        }
+      }
+    },
     "Hours" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/NotchDrop/Localizable.xcstrings
+++ b/NotchDrop/Localizable.xcstrings
@@ -540,24 +540,24 @@
         }
       }
     },
-    "Haptic Feedback" : {
+    "Haptic Feedback: " : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Haptic Feedback"
+            "value" : "Haptic Feedback: "
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "触觉反馈"
+            "value" : "触觉反馈: "
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "觸覺回饋"
+            "value" : "觸覺回饋: "
           }
         }
       }

--- a/NotchDrop/NotchSettingsView.swift
+++ b/NotchDrop/NotchSettingsView.swift
@@ -56,7 +56,7 @@ struct NotchSettingsView: View {
             }
             
             HStack {
-                Toggle("Haptic Feedback", isOn: $vm.hapticFeedback)
+                Toggle("Haptic Feedback: ", isOn: $vm.hapticFeedback)
                 .toggleStyle(SwitchToggleStyle())
                 
                 Spacer()

--- a/NotchDrop/NotchSettingsView.swift
+++ b/NotchDrop/NotchSettingsView.swift
@@ -54,6 +54,13 @@ struct NotchSettingsView: View {
                 }
                 Spacer()
             }
+            
+            HStack {
+                Toggle("Haptic Feedback", isOn: $vm.hapticFeedback)
+                .toggleStyle(SwitchToggleStyle())
+                
+                Spacer()
+            }
         }
         .padding()
         .transition(.scale(scale: 0.8).combined(with: .opacity))

--- a/NotchDrop/NotchViewModel+Events.swift
+++ b/NotchDrop/NotchViewModel+Events.swift
@@ -77,20 +77,20 @@ extension NotchViewModel {
             .throttle(for: .seconds(0.5), scheduler: DispatchQueue.main, latest: false)
             .sink { [weak self] _ in
                 guard NSEvent.pressedMouseButtons == 0 else { return }
-                if self?.hapticFeedback == true {  
-                    self?.hapticSender.send()
-                }
+                self?.hapticSender.send()
             }
             .store(in: &cancellables)
 
         hapticSender
             .throttle(for: .seconds(0.5), scheduler: DispatchQueue.main, latest: false)
-            .sink { _ in
-                NSHapticFeedbackManager.defaultPerformer.perform(
-                    .levelChange,
-                    performanceTime: .now
-                )
-            }
+            .sink { [weak self] _ in
+                    if self?.hapticFeedback == true {
+                        NSHapticFeedbackManager.defaultPerformer.perform(
+                            .levelChange,
+                            performanceTime: .now
+                        )
+                    }
+                }
             .store(in: &cancellables)
 
         $status

--- a/NotchDrop/NotchViewModel+Events.swift
+++ b/NotchDrop/NotchViewModel+Events.swift
@@ -77,7 +77,9 @@ extension NotchViewModel {
             .throttle(for: .seconds(0.5), scheduler: DispatchQueue.main, latest: false)
             .sink { [weak self] _ in
                 guard NSEvent.pressedMouseButtons == 0 else { return }
-                self?.hapticSender.send()
+                if self?.hapticFeedback == true {  
+                    self?.hapticSender.send()
+                }
             }
             .store(in: &cancellables)
 

--- a/NotchDrop/NotchViewModel.swift
+++ b/NotchDrop/NotchViewModel.swift
@@ -76,6 +76,9 @@ class NotchViewModel: NSObject, ObservableObject {
 
     @PublishedPersist(key: "selectedLanguage", defaultValue: .system)
     var selectedLanguage: Language
+    
+    @PublishedPersist(key: "hapticFeedback", defaultValue: true)
+    var hapticFeedback: Bool
 
     let hapticSender = PassthroughSubject<Void, Never>()
 


### PR DESCRIPTION
Adds a setting to disable trackpad haptic feedback. It's a nice touch (literally!), but it can be a bit distracting, particularly since it can be invoked inadvertantly.

![Screenshot 2024-08-09 at 12 32 14 AM](https://github.com/user-attachments/assets/eddd8bca-121e-42bd-a451-dbdd7431e5d7)
