### PR TITLE
Fix Language Picker

### DIFF
--- a/NotchDrop/Language.swift
+++ b/NotchDrop/Language.swift
@@ -54,6 +54,13 @@ enum Language: String, CaseIterable, Identifiable, Codable {
             languageCode = "fr"
         }
 
+        let currentLanguages = UserDefaults.standard.array(forKey: "AppleLanguages") as? [String]
+        let currentLanguageCode = currentLanguages?.first
+        
+        if currentLanguageCode == languageCode {
+            return
+        }
+
         Bundle.setLanguage(languageCode)
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {


### PR DESCRIPTION
Randomly stepped on a bug and decided to contribute
If I select the same language in the settings as the already selected one, the popup telling to restart the app appears. 

https://github.com/user-attachments/assets/6902a381-5d22-4627-bf17-a187cffbe4e7

fixed by adding a current and selected language comparison

https://github.com/user-attachments/assets/b5b9cb68-b065-4ce8-9fe6-a814eae9a5dd

