### PR TITLE
docs: add guide to build from source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,69 @@ For Developers: You can use [NotchNotification](https://github.com/Lakr233/Notch
 
 Download the latest version from [Releases](https://github.com/Lakr233/NotchDrop/releases).
 
+## 🔨 Building from Source
+
+### Prerequisites
+- macOS with Xcode installed
+- Xcode Command Line Tools
+
+### Build Instructions
+
+#### For Personal Daily Use (Production Build)
+
+This creates a production-optimized build that you can use daily on your Mac.
+
+1. Clone the repository:
+```bash
+git clone https://github.com/Lakr233/NotchDrop.git
+cd NotchDrop
+```
+
+2. Build the app in Release configuration:
+```bash
+xcodebuild -project NotchDrop.xcodeproj \
+  -scheme NotchDrop \
+  -configuration Release \
+  clean build \
+  CODE_SIGN_IDENTITY="-" \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+3. Copy the built app to your Applications folder:
+```bash
+cp -R ~/Library/Developer/Xcode/DerivedData/NotchDrop-*/Build/Products/Release/NotchDrop.app ~/Applications/
+```
+
+4. Launch the app:
+```bash
+open ~/Applications/NotchDrop.app
+```
+
+**Note:** On first launch, macOS may show a security warning. To open:
+- Right-click on `NotchDrop.app` in Applications
+- Select "Open"
+- Click "Open" in the security dialog
+
+After the first time, the app will open normally.
+
+#### What This Build Does
+
+- **Release Configuration**: Builds with optimizations enabled for better performance
+- **Self-Signed**: Uses ad-hoc code signing (no Apple Developer account needed)
+- **Production Ready**: Suitable for daily use on your Mac
+- **Binary Size**: ~5.1MB
+- **Location**: `~/Applications/NotchDrop.app`
+
+#### For Development
+
+For development work, open the project in Xcode:
+```bash
+open NotchDrop.xcodeproj
+```
+
+Then build and run using Xcode (⌘R).
+
 ## 🧑‍⚖️ License
 
 [MIT License](./LICENSE)


### PR DESCRIPTION
Updated the README.md with the guide to build the apps from the source code.

I don't know, am I allowed to create pr about this.

Thanks in advance